### PR TITLE
Updates question card background color

### DIFF
--- a/app/components/sections/keys.tsx
+++ b/app/components/sections/keys.tsx
@@ -253,7 +253,7 @@ function QuestionCard() {
 
   return (
     <div
-      className="absolute inset-0 z-10 gap-[4vw] md:gap-[2.083vw] bg-light-purple text-center flex-col flex px-[1.667vw] justify-center pointer-events-auto"
+      className="absolute inset-0 z-10 gap-[4vw] md:gap-[2.083vw] bg-[#A8D6F3] text-center flex-col flex px-[1.667vw] justify-center pointer-events-auto"
       style={{
         display: open ? "flex" : "none",
       }}


### PR DESCRIPTION
Replaces the semantic Tailwind token with an explicit hex background for the question card overlay to match the updated design palette.

Ensures the overlay color renders consistently across environments and avoids reliance on a custom/undefined utility.